### PR TITLE
chore: update API base URL for frontend-backend integration (프론트-백엔드 연동용 API 주소 수정)

### DIFF
--- a/BackEnd/api/server.py
+++ b/BackEnd/api/server.py
@@ -6,7 +6,10 @@ app = FastAPI()
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173"],
+    allow_origins=[
+        "http://localhost:5173",                
+        "https://falsecam.pages.dev"            
+    ],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/src/api.js
+++ b/src/api.js
@@ -1,0 +1,8 @@
+import axios from "axios";
+
+const API_BASE = "https://falsecam.onrender.com";
+
+export function getHealth() {
+  return axios.get(`${API_BASE}/healthz`);
+}
+


### PR DESCRIPTION
프론트엔드(Cloudflare Pages)와 백엔드(FastAPI) 간 연동을 위해
API 호출 주소(API_BASE)를 실제 배포 백엔드 주소로 수정했습니다.

- API_BASE를 https://falsecam.onrender.com 으로 수정하여 연동 가능하도록 함
